### PR TITLE
Return Proper HTTP Status Codes for Errors

### DIFF
--- a/echo/ui/cypress/e2e/youtube-echo.spec.ts
+++ b/echo/ui/cypress/e2e/youtube-echo.spec.ts
@@ -19,7 +19,7 @@ describe("creating an Echo from a YouTube URL", () => {
   describe("using an invalid URL", () => {
     it("loads the app", () => {
       cy.intercept("/api/v1/state").as("getState");
-      cy.intercept("/api/echoes*").as("listEchoes");
+      cy.intercept("GET", "/api/echoes?user_id=*").as("listEchoes");
 
       cy.visit("/");
 
@@ -37,6 +37,7 @@ describe("creating an Echo from a YouTube URL", () => {
     });
 
     it("requires that Echo name is not empty", () => {
+      cy.iframe().find(createEchoNameInput).clear();
       cy.iframe().find(createEchoButton).should("be.disabled");
     });
 
@@ -86,7 +87,9 @@ describe("creating an Echo from a YouTube URL", () => {
 
       cy.intercept("POST", "/api/echoes", req => {
         createdEchoID = req.body.id;
-        req.continue();
+        req.continue(res => {
+          expect(res.statusCode).to.equal(200);
+        });
       });
 
       cy.iframe().contains("Test Echo").should("be.visible");

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lightning==1.8.0rc1
+lightning==1.8.0.post1
 sqlmodel==0.0.8
 pydantic==1.10.2
 uvicorn==0.18.3


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?

With the latest release of the Lightning Framework, we can now use 'raise HTTPException(status_code=4xx)' in the
'configure_api()' handlers to return proper HTTP status codes to the browser and other REST API clients. In the previous version of the framework, raising any exception in these handlers would cause the entire Flow to fail and crash the app.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
