### PR TITLE
Fix Deploy Action by Passing Cluster ID

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -113,6 +113,7 @@ jobs:
         run: |
           lightning run app app.py \
             --cloud \
+            --cluster-id ${{ secrets.LIGHTNING_CLUSTER_ID }} \
             --name "${{ inputs.appName }}" \
             --open-ui false \
             --env ECHO_MODE=production \


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?

Newest release of Lightning CLI requires the '--cluster-id' flag to be passed in order to update an app running in the cloud.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
