### PR TITLE
Alert if Browser Blocks LocalStorage

### DIFF
--- a/echo/ui/src/hooks/useAuth.ts
+++ b/echo/ui/src/hooks/useAuth.ts
@@ -3,6 +3,12 @@ import { useEffect } from "react";
 import { useQuery } from "react-query";
 import { echoClient } from "services/echoClient";
 
+const localStorageBlockedInfo =
+  "https://www.chromium.org/for-testers/bug-reporting-guidelines/uncaught-securityerror-failed-to-read-the-localstorage-property-from-window-access-is-denied-for-this-document/";
+const localStorageBlockedMessage = `
+  This app requires access to local storage in order to work properly. If you are using Chrome, you may need to disable the "Block third-party cookies" setting in order to use this app. For more information, see ${localStorageBlockedInfo}
+  `;
+
 const userIDKey = "echoUserID";
 
 type LoginResponse = {
@@ -10,6 +16,15 @@ type LoginResponse = {
 };
 
 export default function useAuth() {
+  // Some security settings block access to local storage from an <iframe>
+  try {
+    if (typeof window.localStorage === "undefined") {
+      throw new Error();
+    }
+  } catch (error) {
+    window.alert(localStorageBlockedMessage);
+  }
+
   const savedUserID = localStorage.getItem(userIDKey);
 
   const login = useQuery<LoginResponse>("login", () => echoClient.appApi.handleLoginApiLoginGet(), {


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?

Some browser security settings will block access to 'window.localStorage' from an <iframe>. We need local storage in order to save the user ID, so we need to inform the user to enable access in order for the app to work.

Fixes #103 

### Screenshots

![Screenshot_20221108_160421](https://user-images.githubusercontent.com/11700385/200615558-08da9d0f-92b5-4c8b-adbf-bd1035813033.png)

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
