### PR TITLE
Use Unreleased Lightning Version to Fix Launch on Cloud

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-lightning==1.8.0.post1
+# FIXME(alecmerdler): Using unreleased version of `lightning` to fix startup bug...
+git+https://github.com/Lightning-AI/lightning.git@fix_race_condition
+
 sqlmodel==0.0.8
 pydantic==1.10.2
 uvicorn==0.18.3


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?

There is a bug when passing the 'info' argument to 'LightningApp()' which prevents the app from starting in the cloud. Switching to an unreleased version of the Lightning Framework to see if it resolves the issue.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
